### PR TITLE
Quarantine unsuccessful inbox payloads

### DIFF
--- a/cdk/lib/mumble-api.ts
+++ b/cdk/lib/mumble-api.ts
@@ -138,6 +138,7 @@ export class MumbleApi extends Construct {
           OBJECTS_BUCKET_NAME: objectStore.objectsBucket.bucketName,
           DOMAIN_NAME_PARAMETER_PATH:
             systemParameters.domainNameParameter.parameterName,
+          QUARANTINE_BUCKET_NAME: objectStore.quarantineBucket.bucketName,
         },
         memorySize: 256,
         timeout: Duration.seconds(20),
@@ -148,6 +149,7 @@ export class MumbleApi extends Construct {
     systemParameters.domainNameParameter.grantRead(
       receiveInboundActivityLambda,
     );
+    objectStore.quarantineBucket.grantPut(receiveInboundActivityLambda);
     // - receives an activity or object posted to the outbox of a given user
     const receiveOutboundObjectLambda = new PythonFunction(
       this,

--- a/cdk/lib/object-store.ts
+++ b/cdk/lib/object-store.ts
@@ -88,6 +88,8 @@ export interface Props {
 export class ObjectStore extends Construct {
   /** S3 bucket for objects. */
   readonly objectsBucket: s3.IBucket;
+  /** S3 bucket for quarantined objects. */
+  readonly quarantineBucket: s3.IBucket;
   /** DynamoDB table to manage metadata and the history of objects. */
   readonly objectTable: dynamodb.Table;
   /**
@@ -148,6 +150,13 @@ export class ObjectStore extends Construct {
           allowedHeaders: ['*'],
         },
       ],
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
+
+    // S3 bucket for quarantined objects
+    this.quarantineBucket = new s3.Bucket(this, 'QuarantineBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
       removalPolicy: RemovalPolicy.RETAIN,
     });
 


### PR DESCRIPTION
Provisions an S3 bucket for quarantined payloads. `lambda/receive_inbound_activity` saves an input event in the quarantine bucket when it fails to process the event.

Addresses:
- close #21