### PR TITLE
fix(viewer): image overflow

### DIFF
--- a/cdk/viewer/src/components/note/note.module.css
+++ b/cdk/viewer/src/components/note/note.module.css
@@ -135,18 +135,26 @@
       }
     }
 
-    & .image-container {
+    & .attachment-list {
       display: flex;
-      width: 200px;
-      height: 150px;
-      place-items: stretch;
-      place-content: stretch;
+      flex-direction: row;
+      place-items: center;
+      place-content: flex-start;
 
-      & img,
-      & svg {
-        display: block;
-        width: auto;
-        height: auto;
+      & .image-container {
+        max-width: 200px;
+        max-height: 150px;
+
+        &:not(:last-child) {
+          margin-inline-end: 1rem;
+        }
+
+        & img,
+        & svg {
+          display: block;
+          width: 100%;
+          height: 100%;
+        }
       }
     }
   }

--- a/cdk/viewer/src/components/note/note.tsx
+++ b/cdk/viewer/src/components/note/note.tsx
@@ -28,11 +28,13 @@ export default component$<NoteProps>(({ note }: NoteProps) => {
             {note.attachment.length}
             {note.attachment.length > 1 ? 'attachments' : 'attachment'}
           </p>
-          {note.attachment.filter(a => a.type === 'Image').map(attachment => (
-            <article key={attachment.url} class={styles['image-container']}>
-              <img src={attachment.url}></img>
-            </article>
-          ))}
+          <div class={styles['attachment-list']}>
+            {note.attachment.filter(a => a.type === 'Image').map(attachment => (
+              <article key={attachment.url} class={styles['image-container']}>
+                <img src={attachment.url} width={200} height={150}></img>
+              </article>
+            ))}
+          </div>
         </div>
       )}
       <div class={styles['date-section']}>


### PR DESCRIPTION
Fixes:
- fixes #32

Also includes following changes:
- Horizontally orders multiple attachments.
- Suppresses the warnings concerning missing `width` and `height` attributes by specifying the default `width` and `height` to `img`s.