### PR TITLE
fix(viewer): attachment height exceeded bounds

### DIFF
--- a/cdk/viewer/src/components/note/note.module.css
+++ b/cdk/viewer/src/components/note/note.module.css
@@ -138,7 +138,7 @@
     & .attachment-list {
       display: flex;
       flex-direction: row;
-      place-items: center;
+      place-items: stretch;
       place-content: flex-start;
 
       & .image-container {
@@ -152,6 +152,7 @@
         & img,
         & svg {
           display: block;
+          object-fit: scale-down;
           width: 100%;
           height: 100%;
         }


### PR DESCRIPTION
### Issue

- close #32

### Summary

- Vertically stretches the image container to regulate the height
- Specifies `object-fit: scale-down` to fit in the bounding box only when the image size exceeds the box while keeping the aspect ratio