### PR TITLE
Chore(cdk): add type-check script

### DIFF
--- a/cdk/cloudfront-fn/forward-date-header.d.ts
+++ b/cdk/cloudfront-fn/forward-date-header.d.ts
@@ -1,7 +1,7 @@
 // this declaration exists only for unit tests.
 import type { Event, Request } from './types';
 
-function forwardDateHeader(event: Event): Request;
+type ForwardDateHeader = (event: Event) => Request;
 
 // declaration of the __get__ function injected by babel-plugin-rewire.
-export function __get__(name: 'forwardDateHeader'): forwardDateHeader;
+export function __get__(name: 'forwardDateHeader'): ForwardDateHeader;

--- a/cdk/cloudfront-fn/forward-host-header.d.ts
+++ b/cdk/cloudfront-fn/forward-host-header.d.ts
@@ -1,7 +1,7 @@
 // this declaration exists only for unit tests.
 import type { Event, Request } from './types';
 
-function forwardHostHeader(event: Event): Request;
+type ForwardHostHeader = (event: Event) => Request;
 
 // declaration of the __get__ function injected by babel-plugin-rewire.
-export function __get__(name: 'forwardHostHeader'): forwardHostHeader;
+export function __get__(name: 'forwardHostHeader'): ForwardHostHeader;

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -9,6 +9,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
+    "type-check": "tsc --noEmit",
     "setup-domain-name": "ts-node scripts/setup-domain-name.ts",
     "create-user": "ts-node scripts/create-user.ts"
   },

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -26,6 +26,7 @@
   "exclude": [
     "node_modules",
     "cdk.out",
+    "lambda",
     "viewer"
   ]
 }


### PR DESCRIPTION
- `cdk` introduces `type-check` script that runs TypeScript for type checking.
- Fixes `cloudfront-fn/*.d.ts` where function type definitions were incorrect.
- `tsconfig.json` excludes `lambda` folder.