### PR TITLE
Chore(cdk): add comment to cognito-config example

### DIFF
--- a/cdk/configs/cognito-config.example.ts
+++ b/cdk/configs/cognito-config.example.ts
@@ -2,7 +2,7 @@ export default {
   development: {
     // you have to specify a unique name.
     domainPrefix: 'domain-prefix-for-development',
-    // you have to specify at least one URL.
+    // you have to specify at least one URL (DO NOT forget the trailing slash).
     callbackUrls: [
       'http://localhost:5173/',
     ],
@@ -14,7 +14,7 @@ export default {
   production: {
     // you have to specify a unique name.
     domainPrefix: 'domain-prefix-for-production',
-    // you have to specify at least one URL.
+    // you have to specify at least one URL (DO NOT forget the trailing slash).
     callbackUrls: [
       'https://example.com/',
     ],


### PR DESCRIPTION
- The hosted UI of Cognito did not work due to a missing trailing slash. It is worth reminding it in the example.