### PR TITLE
fix(cdk): failed to expand recipients due to 404

### DIFF
--- a/cdk/lambda/states/expand_recipients/index.py
+++ b/cdk/lambda/states/expand_recipients/index.py
@@ -156,7 +156,7 @@ class RecipientCollector(ActivityVisitor):
         try:
             obj = DictObject.resolve(recipient)
         except requests.HTTPError as exc:
-            if exc.response.status_code == 410:
+            if exc.response.status_code in [404, 410]:
                 LOGGER.warning('recipient is gone: %s', recipient)
                 # TODO: issue an event to delete the recipient
                 return


### PR DESCRIPTION
- Fixes the issue that `ExpandRecipients` task failed when a recipient was not found (404 error). Ignores a missing recipient for now.

Issues
- close #39